### PR TITLE
Support Rust 2018 style imports

### DIFF
--- a/parse-generics-shim/src/lib.rs
+++ b/parse-generics-shim/src/lib.rs
@@ -503,26 +503,26 @@ rustup override add nightly-2016-04-06
 macro_rules! parse_generics_shim_util {
     (
         @callback
-        ($cb_name:ident ! ($($cb_arg:tt)*)),
+        ($cb_name:ident $(::$cb_sub:ident)* ! ($($cb_arg:tt)*)),
         $($tail:tt)*
     ) => {
-        $cb_name! { $($cb_arg)* $($tail)* }
+        $cb_name $(::$cb_sub)* ! { $($cb_arg)* $($tail)* }
     };
 
     (
         @callback
-        ($cb_name:ident ! [$($cb_arg:tt)*]),
+        ($cb_name:ident $(::$cb_sub:ident)* ! [$($cb_arg:tt)*]),
         $($tail:tt)*
     ) => {
-        $cb_name! { $($cb_arg)* $($tail)* }
+        $cb_name $(::$cb_sub)* ! { $($cb_arg)* $($tail)* }
     };
 
     (
         @callback
-        ($cb_name:ident ! {$($cb_arg:tt)*}),
+        ($cb_name:ident $(::$cb_sub:ident)* ! {$($cb_arg:tt)*}),
         $($tail:tt)*
     ) => {
-        $cb_name! { $($cb_arg)* $($tail)* }
+        $cb_name $(::$cb_sub)* ! { $($cb_arg)* $($tail)* }
     };
 }
 

--- a/parse-generics-shim/src/parse_constr.rs
+++ b/parse-generics-shim/src/parse_constr.rs
@@ -9,7 +9,7 @@ or distributed except according to those terms.
 */
 #[cfg(not(feature="use-parse-generics-poc"))]
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! parse_constr {
     (
         @parse

--- a/parse-generics-shim/src/parse_constr.rs
+++ b/parse-generics-shim/src/parse_constr.rs
@@ -263,13 +263,13 @@ macro_rules! parse_constr {
 
     (
         ($allow_lt:tt, $allow_tr:tt),
-        then $callback:ident!$callback_arg:tt,
+        then $callback:ident$(::$callback_sub:ident)*!$callback_arg:tt,
         $($body:tt)*
     ) => {
         parse_constr! {
             @parse
             {
-                ($callback!$callback_arg)
+                ($callback$(::$callback_sub)*!$callback_arg)
             },
             ($allow_lt, $allow_tr),
             {},

--- a/parse-generics-shim/src/parse_generics_shim.rs
+++ b/parse-generics-shim/src/parse_generics_shim.rs
@@ -9,7 +9,7 @@ or distributed except according to those terms.
 */
 #[cfg(feature="use-parse-generics-poc")]
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! parse_generics_shim {
     ($($body:tt)*) => {
         parse_generics! { $($body)* }
@@ -18,7 +18,7 @@ macro_rules! parse_generics_shim {
 
 #[cfg(not(feature="use-parse-generics-poc"))]
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! parse_generics_shim {
     (
         @parse_start

--- a/parse-generics-shim/src/parse_generics_shim.rs
+++ b/parse-generics-shim/src/parse_generics_shim.rs
@@ -356,12 +356,12 @@ macro_rules! parse_generics_shim {
 
     (
         $fields:tt,
-        then $callback:ident!$callback_arg:tt,
+        then $callback:ident$(::$callback_sub:ident)*!$callback_arg:tt,
         $($body:tt)*
     ) => {
         parse_generics_shim! {
             @parse_start
-            { $fields, ($callback!$callback_arg) },
+            { $fields, ($callback$(::$callback_sub)*!$callback_arg) },
             $($body)*
         }
     };

--- a/parse-generics-shim/src/parse_where_shim.rs
+++ b/parse-generics-shim/src/parse_where_shim.rs
@@ -9,7 +9,7 @@ or distributed except according to those terms.
 */
 #[cfg(feature="use-parse-generics-poc")]
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! parse_where_shim {
     ($($body:tt)*) => {
         parse_where! { $($body)* }
@@ -18,7 +18,7 @@ macro_rules! parse_where_shim {
 
 #[cfg(not(feature="use-parse-generics-poc"))]
 #[doc(hidden)]
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! parse_where_shim {
     (
         @parse

--- a/parse-generics-shim/src/parse_where_shim.rs
+++ b/parse-generics-shim/src/parse_where_shim.rs
@@ -274,12 +274,12 @@ macro_rules! parse_where_shim {
 
     (
         $fields:tt,
-        then $callback:ident!$callback_arg:tt,
+        then $callback:ident$(::$callback_sub:ident)*!$callback_arg:tt,
         where $($body:tt)*
     ) => {
         parse_where_shim! {
             @parse
-            { $fields, ($callback!$callback_arg) },
+            { $fields, ($callback$(::$callback_sub)*!$callback_arg) },
             { preds: [], },
             $($body)*
         }
@@ -287,12 +287,12 @@ macro_rules! parse_where_shim {
 
     (
         $fields:tt,
-        then $callback:ident!$callback_arg:tt,
+        then $callback:ident$(::$callback_sub:ident)*!$callback_arg:tt,
         $($body:tt)*
     ) => {
         parse_where_shim! {
             @emit_output
-            { $fields, ($callback!$callback_arg) },
+            { $fields, ($callback$(::$callback_sub)*!$callback_arg) },
             { preds: [], },
             $($body)*
         }

--- a/parse-generics-shim/tests/parse_constr.rs
+++ b/parse-generics-shim/tests/parse_constr.rs
@@ -8,7 +8,7 @@ files in the project carrying such notice may not be copied, modified,
 or distributed except according to those terms.
 */
 #![cfg(not(feature="use-parse-generics-poc"))]
-#[macro_use] extern crate parse_generics_shim;
+extern crate parse_generics_shim;
 extern crate rustc_version;
 
 macro_rules! aeqiws {
@@ -29,7 +29,7 @@ macro_rules! aeqiws {
 
 macro_rules! pgts {
     ($($body:tt)*) => {
-        parse_constr! {
+        parse_generics_shim::parse_constr! {
             (true, true),
             then stringify!(),
             $($body)*

--- a/parse-generics-shim/tests/parse_generics.rs
+++ b/parse-generics-shim/tests/parse_generics.rs
@@ -9,7 +9,8 @@ or distributed except according to those terms.
 */
 #![cfg_attr(feature="use-parse-generics-poc", feature(plugin))]
 #![cfg_attr(feature="use-parse-generics-poc", plugin(parse_generics_poc))]
-#[macro_use] extern crate parse_generics_shim;
+extern crate parse_generics_shim;
+extern crate rustc_version;
 
 macro_rules! as_item { ($i:item) => { $i } }
 
@@ -31,7 +32,7 @@ macro_rules! aeqiws {
 
 macro_rules! pgts {
     ($fields:tt, $($body:tt)*) => {
-        parse_generics_shim! {
+        parse_generics_shim::parse_generics_shim! {
             $fields,
             then stringify!(),
             $($body)*
@@ -435,24 +436,24 @@ fn test_passthru() {
         };
     }
 
-    parse_generics_shim! { { .. }, then emit!{a}, X }
-    parse_generics_shim! { { .. }, then emit!{b}, <> X }
-    parse_generics_shim! { { .. }, then emit!{c}, <T> X }
-    parse_generics_shim! { { .. }, then emit!{d}, <T,> X }
-    parse_generics_shim! { { .. }, then emit!{e}, <T, U> X }
-    parse_generics_shim! { { .. }, then emit!{f}, <T, U,> X }
-    parse_generics_shim! { { .. }, then emit!{g}, <T: Copy> X }
-    parse_generics_shim! { { .. }, then emit!{g2}, <T: Copy + Clone> X }
-    parse_generics_shim! { { .. }, then emit!{h}, <'a> X }
-    parse_generics_shim! { { .. }, then emit!{i}, <'a,> X }
-    parse_generics_shim! { { .. }, then emit!{j}, <'a, 'b> X }
-    parse_generics_shim! { { .. }, then emit!{k}, <'a, 'b,> X }
-    parse_generics_shim! { { .. }, then emit!{l}, <'a, 'b: 'a> X }
-    parse_generics_shim! { { .. }, then emit!{l2}, <'a, 'b: 'a, 'c: 'a + 'b> X }
-    parse_generics_shim! { { .. }, then emit!{m}, <'a, T: 'a + Copy> X }
-    parse_generics_shim! { { .. }, then emit!{m2}, <'a, T: 'a + Copy + Clone> X }
-    parse_generics_shim! { { .. }, then emit!{n}, <T: 'static> X }
-    parse_generics_shim! { { .. }, then emit!{o}, <T: From<u8>> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{a}, X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{b}, <> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{c}, <T> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{d}, <T,> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{e}, <T, U> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{f}, <T, U,> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{g}, <T: Copy> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{g2}, <T: Copy + Clone> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{h}, <'a> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{i}, <'a,> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{j}, <'a, 'b> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{k}, <'a, 'b,> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{l}, <'a, 'b: 'a> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{l2}, <'a, 'b: 'a, 'c: 'a + 'b> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{m}, <'a, T: 'a + Copy> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{m2}, <'a, T: 'a + Copy + Clone> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{n}, <T: 'static> X }
+    parse_generics_shim::parse_generics_shim! { { .. }, then emit!{o}, <T: From<u8>> X }
 
     let _ = "the rustc parser is stoopid";
 }

--- a/parse-generics-shim/tests/parse_where.rs
+++ b/parse-generics-shim/tests/parse_where.rs
@@ -9,7 +9,7 @@ or distributed except according to those terms.
 */
 #![cfg_attr(feature="use-parse-generics-poc", feature(plugin))]
 #![cfg_attr(feature="use-parse-generics-poc", plugin(parse_generics_poc))]
-#[macro_use] extern crate parse_generics_shim;
+extern crate parse_generics_shim;
 
 macro_rules! as_item { ($i:item) => { $i } }
 
@@ -31,7 +31,7 @@ macro_rules! aeqiws {
 
 macro_rules! pwts {
     ($fields:tt, $($body:tt)*) => {
-        parse_where_shim! {
+        parse_generics_shim::parse_where_shim! {
             $fields,
             then stringify!(),
             $($body)*


### PR DESCRIPTION
This pull request makes `parse-generics-shim` compatible with Rust 2018 style imports. The introduced changes are twofold:

- It adds `local_inner_macros` to macro definitions so that they can be imported with Rust 2018 style imports. This is demonstrated in `tests/parse_constr.rs`.
- Callback parameters can now refer to pathed macros (`cratename::aaa:bbb!`).

As it stands, `use-parse-generics-poc` appears to be incompatible with any compiler version that is compatible with Rust 2018 style imports. The only way to use `use-parse-generics-poc` now is to grab a very ancient version of nightly, which is very unlikely for anyone to do these days. Thus, I think it's acceptable to ignore `use-parse-generics-poc` for now, at least until it's rewritten as modern procedural macros.